### PR TITLE
Add iOS Support

### DIFF
--- a/lib/include/audiodecodercoreaudio.h
+++ b/lib/include/audiodecodercoreaudio.h
@@ -52,7 +52,11 @@
 #include "apple/CAStreamBasicDescription.h"
 
 #if !defined(__COREAUDIO_USE_FLAT_INCLUDES__)
+#ifdef TARGET_OS_IPHONE
+#include <MobileCoreServices/MobileCoreServices.h>
+#elif defined TARGET_OS_MAC
 #include <CoreServices/CoreServices.h>
+#endif
 #include <CoreAudio/CoreAudioTypes.h>
 #include <AudioToolbox/AudioFile.h>
 #include <AudioToolbox/AudioFormat.h>

--- a/lib/src/audiodecodercoreaudio.cpp
+++ b/lib/src/audiodecodercoreaudio.cpp
@@ -106,9 +106,13 @@ int AudioDecoderCoreAudio::open() {
 	outputFormat.mFormatID = kAudioFormatLinearPCM;
 	outputFormat.mSampleRate = inputFormat.mSampleRate;
 	outputFormat.mChannelsPerFrame = 2;
-    outputFormat.mFormatFlags = kAudioFormatFlagsCanonical;  
-    //kAudioFormatFlagsCanonical means Native endian, float, packed on Mac OS X, 
-    //but signed int for iOS instead.
+	#ifdef TARGET_OS_IPHONE
+	outputFormat.mFormatFlags = kAudioFormatFlagIsFloat;
+	#elif defined TARGET_OS_MAC
+	outputFormat.mFormatFlags = kAudioFormatFlagsCanonical;
+	//kAudioFormatFlagsCanonical means Native endian, float, packed on Mac OS X,
+	//but signed int for iOS instead.
+	#endif
 
     //Note iPhone/iOS only supports signed integers supposedly:
     //outputFormat.mFormatFlags = kAudioFormatFlagIsSignedInteger;


### PR DESCRIPTION
Add conditionals for compile-time iOS Support.
We need float output (not signed integer) for
ofSoundBuffer (not SInt as specified by libaudiodecoder).

ping @kylemcdonald 